### PR TITLE
Add --no-create option for use on existing zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This solution automates the migration of an AWS Route 53 hosted zone between AWS
 
 1. It exports original hosted zone records on a JSON file from the source AWS account
 
-2. Creates the new empty hosted zone on the destination account
+2. Creates the new empty hosted zone on the destination account, unless `--no-create` option is provided
 
 3. Edits the exported JSON file with the required changes:
    - removes original [SOA and NS records](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html) because they are already present in the new hosted zone created in the destination account;
@@ -54,12 +54,12 @@ If the hosted zone you want to import is "private", you will be asked for additi
 - the VPC ID to associate with the private hosted zone
 <br/>
 
-Dry run option:
+Dry run and no create option:
 
 ```
 % sh r53_migrator.sh --help
 
-Usage: r53_migrator.sh [--dry-run]
+Usage: r53_migrator.sh [--dry-run] [--no-create]
 
 %
 ```

--- a/functions.sh
+++ b/functions.sh
@@ -57,13 +57,26 @@ check_private_hosted_zone() {
 }
 
 # Check if the hosted zone already exists in the destination account
+# Output found zone id of empty string
 check_hosted_zone_name() {
-    if [ -z "$(aws --profile "$DEST_PROFILE" route53 list-hosted-zones --query "HostedZones[?Name=='$1'].Id" --output text)" ]; then
-        log "[OK] Hosted Zone Name '$1' does not exist in the destination account."
-    else
-        log "${bold}[ERROR]${normal} Hosted Zone Name '$1' already exists in the destination account."
-        exit 1
+    DEST_ZONE_ID="$(aws --profile "$DEST_PROFILE" route53 list-hosted-zones --query "HostedZones[?Name=='$1'].Id" --output text)"
+    if [ -z "$DEST_ZONE_ID" ]; then
+        DEST_ZONE_EXISTS=true
+        if [ "$DEST_ZONE_EXISTS" == "$NOCREATE" ]; then
+            DEST_ZONE_ERROR_STATUS="[OK]"
+        else
+            DEST_ZONE_ERROR_STATUS="${bold}[ERROR]${normal}"
+        fi
+        if [ "$DEST_ZONE_EXISTS" == "true" ]; then
+            log "${DEST_ZONE_ERROR_STATUS} Hosted Zone Name '$1' does not exist in the destination account."
+        else
+            log "${DEST_ZONE_ERROR_STATUS} Hosted Zone Name '$1' already exists in the destination account."
+        fi
+        if [ "DEST_ZONE_ERROR_STATUS" != "[OK]" ]; then
+            exit 1
+        fi
     fi
+    echo -n "$DEST_ZONE_ID"
 }
 
 check_dnssec() {
@@ -101,7 +114,7 @@ extract_and_convert_zone() {
 
     # Check if the hosted zone name already exists in the destination account
     log "[INFO] Checking if Hosted Zone name already exists in the destination account..."
-    check_hosted_zone_name "$HOSTED_ZONE_NAME"
+    DEST_HOSTED_ZONE_ID="$(check_hosted_zone_name "$HOSTED_ZONE_NAME")"
 
     if [ "$DRYRUN" != "true" ]; then
         log "-- STARTING MIGRATION FROM $SOURCE_PROFILE to $DEST_PROFILE"
@@ -130,23 +143,25 @@ extract_and_convert_zone() {
 
     if [ "$DRYRUN" != "true" ]; then
 
-        # Create the new hosted zone in the destination AWS account
-        if [ "$HOSTED_ZONE_PRIVATE" == "False" ]; then
-            DEST_HOSTED_ZONE_ID=$(aws --profile "$DEST_PROFILE" route53 create-hosted-zone --name "$HOSTED_ZONE_NAME" --caller-reference "$(date +%s)" --hosted-zone-config Comment="Migrated from $HOSTED_ZONE_ID" --query 'HostedZone.Id' --output text)
-            # Check if the new hosted zone was created successfully
-            if [ $? -ne 0 ]; then
-                log "${bold}[ERROR]${normal} Failed to create the destination hosted zone."
-                # Clean up - delete the destination hosted zone
-                aws --profile "$DEST_PROFILE" route53 delete-hosted-zone --id "$DEST_HOSTED_ZONE_ID" > /dev/null 2>&1
-                exit 1
-            fi
-        else
-            DEST_HOSTED_ZONE_ID=$(aws --profile "$DEST_PROFILE" route53 create-hosted-zone --name "$HOSTED_ZONE_NAME" --caller-reference "$(date +%s)" --vpc "VPCRegion=$HOSTED_ZONE_REGION,VPCId=$HOSTED_ZONE_VPC_ID" --hosted-zone-config Comment="Migrated from $HOSTED_ZONE_ID" --query 'HostedZone.Id' --output text)
-            if [ $? -ne 0 ]; then
-                log "${bold}[ERROR]${normal} Failed to create the destination hosted zone."
-                # Clean up - delete the destination hosted zone
-                aws --profile "$DEST_PROFILE" route53 delete-hosted-zone --id "$DEST_HOSTED_ZONE_ID" > /dev/null 2>&1
-                exit 1
+        if [ -z "$DEST_HOSTED_ZONE_ID" ]; then
+            # Create the new hosted zone in the destination AWS account
+            if [ "$HOSTED_ZONE_PRIVATE" == "False" ]; then
+                DEST_HOSTED_ZONE_ID=$(aws --profile "$DEST_PROFILE" route53 create-hosted-zone --name "$HOSTED_ZONE_NAME" --caller-reference "$(date +%s)" --hosted-zone-config Comment="Migrated from $HOSTED_ZONE_ID" --query 'HostedZone.Id' --output text)
+                # Check if the new hosted zone was created successfully
+                if [ $? -ne 0 ]; then
+                    log "${bold}[ERROR]${normal} Failed to create the destination hosted zone."
+                    # Clean up - delete the destination hosted zone
+                    aws --profile "$DEST_PROFILE" route53 delete-hosted-zone --id "$DEST_HOSTED_ZONE_ID" > /dev/null 2>&1
+                    exit 1
+                fi
+            else
+                DEST_HOSTED_ZONE_ID=$(aws --profile "$DEST_PROFILE" route53 create-hosted-zone --name "$HOSTED_ZONE_NAME" --caller-reference "$(date +%s)" --vpc "VPCRegion=$HOSTED_ZONE_REGION,VPCId=$HOSTED_ZONE_VPC_ID" --hosted-zone-config Comment="Migrated from $HOSTED_ZONE_ID" --query 'HostedZone.Id' --output text)
+                if [ $? -ne 0 ]; then
+                    log "${bold}[ERROR]${normal} Failed to create the destination hosted zone."
+                    # Clean up - delete the destination hosted zone
+                    aws --profile "$DEST_PROFILE" route53 delete-hosted-zone --id "$DEST_HOSTED_ZONE_ID" > /dev/null 2>&1
+                    exit 1
+                fi
             fi
         fi
     

--- a/r53_migrator.sh
+++ b/r53_migrator.sh
@@ -7,14 +7,19 @@
 . ./config
 . ./functions.sh
 
+export NOCREATE=false
+
 if [ "$#" -gt 0 ]; then
     case "$1" in
         --dry-run)
             export DRYRUN="true"
             ;;
+        --no-create)
+            export NOCREATE="true"
+            ;;
         --help)
             echo ""
-            echo "Usage: $0 [--dry-run]"
+            echo "Usage: $0 [--dry-run] [--no-create]"
             echo ""
             exit 1
             ;;
@@ -22,7 +27,7 @@ if [ "$#" -gt 0 ]; then
             echo ""
             echo "[ERROR] Unknown argument '$1'"
             echo ""
-            echo "Usage: $0 [--dry-run]"
+            echo "Usage: $0 [--dry-run] [--no-create]"
             echo ""
             exit 1
             ;;
@@ -59,6 +64,9 @@ echo "" >> "$WORK_DIR/$HOSTED_ZONE_ID/$LOG_FILE"
 
 # Log dry-run execution
 if [ "$DRYRUN" == "true" ]; then log "[INFO] Dry-run execution enabled"; fi
+
+# Log no-create execution
+if [ "$NOCREATE" == "true" ]; then log "[INFO] Target zone won't be created"; fi
 
 # Checking if specified AWS CLI profile are correct
 log "[INFO] Checking AWS CLI profiles..."


### PR DESCRIPTION
*Description of changes:*

The script `r53_migrator.sh` creates the target Route53 hosted zone. But this is not always desirable - sometimes is is already created, tagged and configured with for example `terraform`.

For such situation I've added `--no-create` option to the script.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.